### PR TITLE
Added the asset mapping to the markup during template generation

### DIFF
--- a/Rapid Umbraco Conversion Tool/Rapid.Umbraco.Conversion.Tool/Entities/FileCopyPair.cs
+++ b/Rapid Umbraco Conversion Tool/Rapid.Umbraco.Conversion.Tool/Entities/FileCopyPair.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -8,11 +9,16 @@ namespace Codetreehouse.RapidUmbracoConverter.Tools.Entities
 {
     public class FileCopyPair
     {
-        public FileCopyPair(string directoryRoot, string source, string destination)
+        public FileCopyPair(string directoryRoot, string source, string markupReference, string destination)
         {
             DirectoryRoot = directoryRoot;
             Source = source;
+            MarkupReference = markupReference;
+
             Destination = destination;
+
+            CombinedSource = CombinePathsForCopy(directoryRoot, source);
+            CombinedDestination = CombinePathsForCopy(directoryRoot, destination);
         }
 
         public string Destination { get; internal set; }
@@ -20,22 +26,35 @@ namespace Codetreehouse.RapidUmbracoConverter.Tools.Entities
         public string Source { get; internal set; }
 
 
-        public string CombinedSource
+        public string CombinedSource { get; private set; }
+        public string CombinedDestination { get; private set; }
+        public string MarkupReference { get; private set; }
+
+        public string CombinePathsForCopy(string directoryRoot, string specific)
         {
-            get
+            string[] pathArray = directoryRoot.Replace("~", "").Split(new String[] { "\\" }, StringSplitOptions.RemoveEmptyEntries);
+            string[] specificRoot = specific.Replace("~", "").Split(new String[] { "/" }, StringSplitOptions.RemoveEmptyEntries);
+
+            string combinedPath = String.Empty;
+
+            foreach (var item in pathArray)
             {
-                return (DirectoryRoot += Source).Replace("/~/", "/").Replace("/", "\\").Replace("\\~", "\\");
+                Debug.WriteLine(combinedPath);
+                combinedPath += item;
+                combinedPath += "/";
             }
+
+            foreach (var item in specificRoot)
+            {
+                Debug.WriteLine(combinedPath);
+                combinedPath += item;
+                combinedPath += "/";
+            }
+            Debug.WriteLine(combinedPath);
+
+            return combinedPath;
         }
 
-        public string CombinedDestination
-        {
-            get
-            {
-                return (DirectoryRoot += Destination).Replace("/~/", "/").Replace("/", "\\").Replace("\\~", "\\");
-
-            }
-        }
 
     }
 }

--- a/Rapid Umbraco Conversion Tool/Rapid.Umbraco.Conversion.Tool/UmbracoTemplateLogic.cs
+++ b/Rapid Umbraco Conversion Tool/Rapid.Umbraco.Conversion.Tool/UmbracoTemplateLogic.cs
@@ -63,18 +63,16 @@ namespace Codetreehouse.RapidUmbracoConverter.Tools
                     template.Content += fileContents;
 
 
-                    ////Replace any of the copied asset directories
-                    //foreach (FileCopyPair copyPair in assetDirectories)
-                    //{
-                    //    //Replace any root based source paths with relative 
-                    //    template.Content = template.Content.Replace(copyPair.Source.Replace("~/", ""), copyPair.Destination);
+                    //Replace any of the copied asset directories
+                    foreach (FileCopyPair copyPair in assetDirectories)
+                    {
+                        string replaceString = $"href=\"{copyPair.MarkupReference}";
+                        template.Content = template.Content.Replace(replaceString, $"href=\"{copyPair.Destination}");
 
-                    //    //template.Content = template.Content.Replace(copyPair.Source.Replace("/", ""), "~/");
-
-
-                    //    //Do the final copy with all paths that are server relative
-                    //    template.Content = template.Content.Replace(copyPair.Source, copyPair.Destination);
-                    //}
+                        replaceString = $"src=\"{copyPair.MarkupReference}";
+                        template.Content = template.Content.Replace(replaceString, $"src=\"{copyPair.Destination}");
+                    }
+                    
 
                     //Save the template to initialise the ID
                     Debug.WriteLine($"Saving template: {template.Name}");


### PR DESCRIPTION
The library will not copy specific directories that contain assets within the template such as css, js, or images to a new directory. Any references in markup will be pointed at the new directory.